### PR TITLE
vscode-ryzelang: add settings capability for langserver path

### DIFF
--- a/vscode-ryzelang/package.json
+++ b/vscode-ryzelang/package.json
@@ -25,7 +25,19 @@
       "language": "ryze",
       "scopeName": "source.ryze",
       "path": "./syntaxes/ryze.tmLanguage.json"
-    }]
+      }
+    ],
+    "configuration": {
+      "title": "ryzelang",
+      "type": "object",
+      "properties": {
+        "ryzelang.languageServer.path": {
+          "type": "string",
+          "default": "ryzelang-ls",
+          "description": "Path to the Ryzelang language server"
+        }
+      }
+    }
   },
   "scripts": {
     "compile": "tsc -p .",

--- a/vscode-ryzelang/src/extension.ts
+++ b/vscode-ryzelang/src/extension.ts
@@ -14,8 +14,9 @@ export function activate(context: ExtensionContext) {
 	// The server is implemented in Rust.
 	// We'll point to the binary we've already built.
 	// In a real extension, we would bundle this!
-	const serverPath = path.join(context.extensionPath, '..', 'target', 'debug', 'ryzelang-ls');
-
+	const configuration = workspace.getConfiguration()
+	const serverPath = configuration.get("ryzelang.languageServer.path") as string
+	
 	const run: Executable = {
 		command: serverPath,
 		options: {


### PR DESCRIPTION
Introduces a configuration contribution point for the vscode extension for setting the path for running the ryzelang-ls, defaulting to "ryzelang-ls", instead of the current hardcoded relative path that looks for it in vscode extensions directory.

I tried following the existing instructions for ["Setup (Local Development)"](https://github.com/ztalarick/ryzelang/blob/main/vscode-ryzelang/README.md) for the vscode extension, but that lead to the language server never getting started, I think this is a better way of doing it than the hardcoded path.